### PR TITLE
feat: add csv logging for prompt, entry, cat & response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .streamlit/secrets.toml
+logs/

--- a/app.py
+++ b/app.py
@@ -37,12 +37,12 @@ if st.button("Submit"):
 # --- Display Response ---
 if st.session_state.submitted and st.session_state.response:
     category = st.session_state.response.get("category")
-    response_text = st.session_state.response.get("response_text")
+    response_text = st.session_state.response.get("response_text", "").strip()
 
     if category == "safety":
         st.error(response_text)
         st.info("If you're struggling, please reach out to someone you trust or seek professional help.")
-    elif category == "unclear":
+    elif category == "unclear" and not response_text:
         st.warning("Hmm, we couldn't quite understand that. Try again?")
     else:
         st.success(response_text)


### PR DESCRIPTION
### summary
log every entry submission to a csv file, capturing:
- timestamp
- prompt
- user entry
- ai-determined category
- ai response text
- whether safety flag triggered

### why
provide traceability and allow:
- response analysis for quality and failure points
- review unclear entries for future prompt engineering or RAG use
- track how users are interacting with different prompts
- improve safety handling and model refinement
