### PR TITLE
feat: add supabase for logging

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ python-dotenv
 vaderSentiment
 thefuzz
 python-Levenshtein
+supabase


### PR DESCRIPTION
add logging of all journal entries and safety flags to supabase for scalable storage and review.

### key changes:
- added log_to_supabase() to utils.py
- updated classify_and_respond() to log to both csv and supabase
- supabase config handled via st.secrets
- table schema incl timestamp, prompt, entry, category, response_text, and safety_flagged